### PR TITLE
fix: typos and linking between EN/ CN readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ On a Windows system, you can use the Rufus tool to flash the firmware to a TF ca
 1. Insert the TF card into your computer and start the Rufus tool. Click the “Select” button in the interface and choose the firmware file to be flashed. ![rufus-flash-from-file](https://www.kendryte.com/k230_canmv/en/main/_images/rufus_select.png)
 2. Click the “Start” button, and Rufus will automatically proceed with the flashing. The progress bar will display the flashing progress, and the system will prompt “Ready” upon completion. ![rufus-flash](https://www.kendryte.com/k230_canmv/en/main/_images/rufus_start.png) ![rufus-sure](https://www.kendryte.com/k230_canmv/en/main/_images/rufus_sure.png) ![rufus-warning](https://www.kendryte.com/k230_canmv/en/main/_images/rufus_warning.png) ![rufus-finish](https://www.kendryte.com/k230_canmv/en/main/_images/rufus_finish.png)
 
-### 2 Flashing on Linux Platform
+### 2. Flashing on Linux Platform
 
 Before inserting the TF card, first run the following command to check the current storage devices:
 

--- a/README.md
+++ b/README.md
@@ -228,11 +228,6 @@ time make log
 
 After compilation, the image files will be generated in the `canmv_k230_pro/canmv_k230/output/xxxx/xxx.img` directory.
 
-
-```
-
-```
-
 ## Firmware download
 
 ### 1. Flashing on Windows Platform

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@
 - [Information](#information)
 - [DependentLibraries](#dependentlibraries)
 
-## Describe
+## Description
 
 T-Display-K230 is a development board featuring a high-definition AMOLED display, based on the k230. <!--designed for standalone battery connectivity.-->
 
-## Preview
+### Preview
 
-### Actual Product Image
+#### Actual Product Image
 
 <p align="center" width="100%">
     <img src="image/k230_display_product.png" alt="">
@@ -57,7 +57,7 @@ T-Display-K230 is a development board featuring a high-definition AMOLED display
 
 ## Module
 
-### 1.MCU
+### 1. MCU
 
 * Chip: k230
 * For more details, please visit    [k230 Datasheet](datasheet/K230_datasheet.pdf)
@@ -98,7 +98,7 @@ T-Display-K230 is a development board featuring a high-definition AMOLED display
 
 #### **k230**
 
-# App Compilation
+## App Compilation
 
 change to current dir canmv_k230
 
@@ -115,9 +115,9 @@ default app: sample_display
 
 rename sample_display.elf to app.elf  copy to sdcard, Power on again and start running by default.
 
-# Advanced - Custom Firmware
+## Advanced - Custom Firmware
 
-## 1. Overview
+### 1. Overview
 
 Note
 
@@ -125,7 +125,7 @@ This chapter introduces how to develop on the K230 CanMV. If you have no custom 
 
 The K230 CanMV is developed based on the K230 SDK 
 
-## 2. Setting Up the Development Environment
+### 2. Setting Up the Development Environment
 
 | Host Environment            | Description                                                  |
 | --------------------------- | ------------------------------------------------------------ |
@@ -133,7 +133,7 @@ The K230 CanMV is developed based on the K230 SDK
 
 Currently, K230 CanMV has only been verified to compile in a Linux environment. Other Linux versions have not been tested, so compatibility with other systems cannot be guaranteed.
 
-### 2.1 Local Build Environment
+#### 2.1 Local Build Environment
 
 - Update APT sources (optional)
 
@@ -142,8 +142,6 @@ sudo bash -c 'cp /etc/apt/sources.list /etc/apt/sources_bak.list && \
   sed -i "s/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g" /etc/apt/sources.list && \
   sed -i "s/security.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g" /etc/apt/sources.list'
 ```
-
-
 
 - Install necessary dependencies
 
@@ -178,7 +176,6 @@ pip3 install -U pyyaml pycryptodome gmssl jsonschema jinja2
 ```
 
 
-
 - Install the repo tool
 
 ```sh
@@ -189,11 +186,9 @@ echo 'export PATH="${HOME}/.bin:${PATH}"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
+### 3. Compilation Process
 
-
-## 3. Compilation Process
-
-### 3.1 Source Code Download
+#### 3.1 Source Code Download
 
 The source code of CanMV-K230 is hosted on Github. Users can download the source code using the repo tool.
 
@@ -206,8 +201,7 @@ git clone https://github.com/Xinyuan-LilyGO/T-Display-K230_canmv_rt.git
 ```
 
 
-
-### 3.2 Code Preparation
+#### 3.2 Code Preparation
 
 When compiling for the first time, you need to download the toolchain. The following command only needs to be executed once.
 
@@ -218,8 +212,7 @@ make dl_toolchain
 ```
 
 
-
-### 3.3 Compilation
+#### 3.3 Compilation
 
 Select the corresponding board configuration file according to actual needs, and then start compiling.
 
@@ -233,16 +226,14 @@ time make log
 ```
 
 
-
 After compilation, the image files will be generated in the `canmv_k230_pro/canmv_k230/output/xxxx/xxx.img` directory.
 
 
-
 ```
 
 ```
 
-### firmware download
+## Firmware download
 
 ### 1. Flashing on Windows Platform
 
@@ -258,7 +249,6 @@ Before inserting the TF card, first run the following command to check the curre
 ```sh
 ls -l /dev/sd\*
 ```
-
 
 
 Next, insert the TF card into the host machine and run the same command again to identify the newly added device node, which is the device node for the TF card.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
  * @Author: LILYGO
  * @Date: 2025-02-20 16:13:14
  * @LastEditors: Please set LastEditors
- * @LastEditTime: 2025-03-05 18:07:02
+ * @LastEditTime: 2025-06-17 09:00:00
  * @License: GPL 3.0
 -->
 <h1 align = "center">T-Display-K230_canmv_rt</h1>
@@ -14,8 +14,8 @@
     <img src="image/k230_display_product.png" alt="">
 </p>
 
+**English** | [中文](README_CN.md)
 
-## **English**
 
 ## Version iteration:
 | Version                              | Update date                       |Update description|
@@ -60,7 +60,7 @@ T-Display-K230 is a development board featuring a high-definition AMOLED display
 ### 1.MCU
 
 * Chip: k230
-* For more details, please visit    [k230 Datashee](datasheet/K230_datasheet.pdf)
+* For more details, please visit    [k230 Datasheet](datasheet/K230_datasheet.pdf)
 
 ### 2. Screen
 
@@ -103,17 +103,17 @@ T-Display-K230 is a development board featuring a high-definition AMOLED display
 change to current dir canmv_k230
 
 
-      cd anmv_k230/src/rtsmart/mpp
-      source build.sh
-      cd /userapps/sample/sample_display
+      cd canmv_k230/src/rtsmart/mpp
+      source build_env.sh
+      cd userapps/sample/sample_display
       make
 
-in the dir sample/elf     generate sample_display.elf
+in the directory sample/elf     generate sample_display.elf
 
 default app: sample_display
 
 
-rename sample_display.elf to app.elf  copy to sdcard  ,Power on again and start running by default.
+rename sample_display.elf to app.elf  copy to sdcard, Power on again and start running by default.
 
 # Advanced - Custom Firmware
 
@@ -137,7 +137,7 @@ Currently, K230 CanMV has only been verified to compile in a Linux environment. 
 
 - Update APT sources (optional)
 
-```
+```sh
 sudo bash -c 'cp /etc/apt/sources.list /etc/apt/sources_bak.list && \
   sed -i "s/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g" /etc/apt/sources.list && \
   sed -i "s/security.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g" /etc/apt/sources.list'
@@ -147,7 +147,7 @@ sudo bash -c 'cp /etc/apt/sources.list /etc/apt/sources_bak.list && \
 
 - Install necessary dependencies
 
-```
+```sh
 # Add support for i386 architecture
 sudo bash -c 'dpkg --add-architecture i386 && \
   apt-get clean all && \
@@ -164,7 +164,7 @@ sudo bash -c 'dpkg --add-architecture i386 && \
 
 - Update PIP sources (optional)
 
-```
+```sh
 pip3 config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple && \
 pip3 config set global.extra-index-url "https://mirrors.aliyun.com/pypi/simple https://mirrors.cloud.tencent.com/pypi/simple"
 ```
@@ -173,7 +173,7 @@ pip3 config set global.extra-index-url "https://mirrors.aliyun.com/pypi/simple h
 
 - Install Python dependencies
 
-```
+```sh
 pip3 install -U pyyaml pycryptodome gmssl jsonschema jinja2
 ```
 
@@ -181,7 +181,7 @@ pip3 install -U pyyaml pycryptodome gmssl jsonschema jinja2
 
 - Install the repo tool
 
-```
+```sh
 mkdir -p ~/.bin
 curl https://storage.googleapis.com/git-repo-downloads/repo > ~/.bin/repo
 chmod a+rx ~/.bin/repo
@@ -197,7 +197,7 @@ source ~/.bashrc
 
 The source code of CanMV-K230 is hosted on Github. Users can download the source code using the repo tool.
 
-```
+```sh
 # It's recommended to create a directory in the user's home directory before downloading the code
 mkdir -p ~/canmv_k230_pro && cd ~/canmv_k230_pro
 
@@ -211,7 +211,7 @@ git clone https://github.com/Xinyuan-LilyGO/T-Display-K230_canmv_rt.git
 
 When compiling for the first time, you need to download the toolchain. The following command only needs to be executed once.
 
-```
+```sh
 cd canmv_k230
 # Download the toolchain when running for the first time
 make dl_toolchain
@@ -223,7 +223,7 @@ make dl_toolchain
 
 Select the corresponding board configuration file according to actual needs, and then start compiling.
 
-```
+```sh
 # List available configuration options
 make list_def 
 # Select the corresponding board configuration file
@@ -255,7 +255,7 @@ On a Windows system, you can use the Rufus tool to flash the firmware to a TF ca
 
 Before inserting the TF card, first run the following command to check the current storage devices:
 
-```
+```sh
 ls -l /dev/sd\*
 ```
 
@@ -265,7 +265,7 @@ Next, insert the TF card into the host machine and run the same command again to
 
 Assuming the device node for the TF card is `/dev/sdc`, you can use the following command to flash the firmware to the TF card:
 
-```
+```sh
 sudo dd if=sysimage-sdcard.img of=/dev/sdc bs=1M oflag=sync
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <h1 align = "center">T-Display-K230_canmv_rt</h1>
 
 <p align="center" width="100%">
-    <img src="image/k230_display_product.png" alt="">
+    <img src="image/k230_display_product.png" alt="T-Display K230 development board">
 </p>
 
 **English** | [中文](README_CN.md)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,5 +1,9 @@
 # T-Display-K230_canmv_rt
 
+<p align="center" width="100%">
+    <img src="image/k230_display_product.png" alt="T-Display K230 development board">
+</p>
+
 [English](README.md) | **中文**
 
 ## K230芯片简介

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,6 +1,6 @@
 # T-Display-K230_canmv_rt
 
-[English](README_CN.md) | **中文**
+[English](README.md) | **中文**
 
 ## K230芯片简介
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,4 +1,7 @@
 # T-Display-K230_canmv_rt
+
+[English](README_CN.md) | **中文**
+
 ## K230芯片简介
 
 K230芯片是嘉楠科技 Kendryte®系列AIoT芯片中的最新一代SoC产品。该芯片采用全新的多异构单元加速计算架构，集成了2个RISC-V高能效计算核心，内置新一代KPU（Knowledge Process Unit）智能计算单元，具备多精度AI算力，广泛支持通用的AI计算框架，部分典型网络的利用率超过了70%。
@@ -212,7 +215,7 @@ Operator:
 编译固件：
 
 
-      cd anmv_k230
+      cd canmv_k230
       time make log
      
 canmv_k230/output/k230_canmv_v3p0    生成CanMV-K230-V3P0_rtsmart_localnncase_v2.9.0.img   可烧录至sd卡
@@ -220,12 +223,12 @@ canmv_k230/output/k230_canmv_v3p0    生成CanMV-K230-V3P0_rtsmart_localnncase_v
 
 
 compile app:
-change to current dir anmv_k230
+change to current dir canmv_k230
 
       
-      cd anmv_k230/src/rtsmart/mpp
-      source build.sh
-      cd /userapps/sample/sample_display
+      cd canmv_k230/src/rtsmart/mpp
+      source build_env.sh
+      cd userapps/sample/sample_display
       make
 in the dir sample/elf     generate sample_display.elf
 

--- a/canmv_k230/src/rtsmart/mpp/README.md
+++ b/canmv_k230/src/rtsmart/mpp/README.md
@@ -1,55 +1,58 @@
 # mpp
 
-## 概述
-
-mpp(Media Process Platform 媒体处理平台)是嘉楠科技开发的一整套适配K230的多媒体组件，包含内核的驱动库，用户态的API库及各样的sample程序。
-
-## 编译
-
-### 编译准备
-
-在mpp目录下配置环境变量`source build_env.sh`之后即可对mpp进行编译了
-
-**注意：编译前请确保mpp在sdk目录的正确位置中。**
-
-### 编译详细
-
-- 编译全部的kernel层代码
-
-  进入目录 `k230_sdk/src/src/big/mpp/kerne`
-
-  运行`make`命令
+**English** | [中文](README_CN.md)
 
 
-- 单独编译某个kernel驱动库
+## Overview
+
+mpp (Media Process Platform) is a suite of multimedia components developed by Canaan Creative, specifically designed for the K230 chip. It includes kernel driver libraries, user-space API libraries, and various sample programs.
+
+## Compilation
+
+### Preparation
+
+After configuring the environment variables in the mpp directory with `source build_env.sh`, you can proceed to compile the mpp.
+
+**Note: Ensure that mpp is correctly positioned within the sdk directory before compiling.**
+
+### Detailed Compilation
+
+- Compile all kernel layer code:
+
+  Navigate to the directory `k230_sdk/src/big/mpp/kernel`
+
+  Run the `make` command
+
+
+- Compile the specific kernel driver library:
   
-  进入某个驱动目录例如 `k230_sdk/src/big/mpp/kernel/fft`
+  Navigate to a specific driver directory, e.g. `k230_sdk/src/big/mpp/kernel/fft`
 
-  运行`make`命令
+  Run the `make` command
 
-- 编译全部的user层api代码
+- Compile all user apps API code:
 
-  进入目录 `k230_sdk/src/big/mpp/userapps/src`
+  Navigate to the directory `k230_sdk/src/big/mpp/userapps/src`
 
-  运行`make`命令
+  Run the `make` command
 
 
-- 单独编译某个user层api库
+- Compile a specific user app API library:
   
-  进入某个api源码目录例如 `k230_sdk/src/big/mpp/userapps/src/sensor`
+  Navigate to a specific API source code directory, e.g. `k230_sdk/src/big/mpp/userapps/src/sensor`
 
-  运行`make`命令
+  Run the `make` command
 
-- 编译全部的user层sample代码
+- Compile all user apps sample code:
 
-  进入目录 `k230_sdk/src/big/mpp/userapps/sample`
+  Navigate to the directory `k230_sdk/src/big/mpp/userapps/sample`
 
-  运行`make`命令
+  Run the `make` command
 
 
-- 单独编译某个user层sample
+- Compile a specific user app sample:
   
-  进入某个sample目录例如 `k230_sdk/src/big/mpp/userapps/sample/sample_fft`
+  Navigate to a specific sample directory, e.g. `k230_sdk/src/big/mpp/userapps/sample/sample_fft`
 
-  运行`make`命令
+  Run the `make` command
 

--- a/canmv_k230/src/rtsmart/mpp/README_CN.md
+++ b/canmv_k230/src/rtsmart/mpp/README_CN.md
@@ -1,0 +1,57 @@
+# mpp
+
+[English](README_CN.md) | **中文**
+
+## 概述
+
+mpp (Media Process Platform 媒体处理平台) 是嘉楠科技开发的一整套适配K230的多媒体组件，包含内核的驱动库，用户态的API库及各样的sample程序。
+
+## 编译
+
+### 编译准备
+
+在mpp目录下配置环境变量`source build_env.sh`之后即可对mpp进行编译了
+
+**注意：编译前请确保mpp在sdk目录的正确位置中。**
+
+### 编译详细
+
+- 编译全部的kernel层代码
+
+  进入目录 `k230_sdk/src/big/mpp/kernel`
+
+  运行`make`命令
+
+
+- 单独编译某个kernel驱动库
+  
+  进入某个驱动目录例如 `k230_sdk/src/big/mpp/kernel/fft`
+
+  运行`make`命令
+
+- 编译全部的user层api代码
+
+  进入目录 `k230_sdk/src/big/mpp/userapps/src`
+
+  运行`make`命令
+
+
+- 单独编译某个user层api库
+  
+  进入某个api源码目录例如 `k230_sdk/src/big/mpp/userapps/src/sensor`
+
+  运行`make`命令
+
+- 编译全部的user层sample代码
+
+  进入目录 `k230_sdk/src/big/mpp/userapps/sample`
+
+  运行`make`命令
+
+
+- 单独编译某个user层sample
+  
+  进入某个sample目录例如 `k230_sdk/src/big/mpp/userapps/sample/sample_fft`
+
+  运行`make`命令
+


### PR DESCRIPTION
<img width="309" alt="image" src="https://github.com/user-attachments/assets/76bac732-d48b-48f9-bbd1-ce81eef310d5" />

see https://github.com/mcuw/T-Display-K230_canmv_rt/tree/fix/1-typos